### PR TITLE
#13 Mark config topics retained.

### DIFF
--- a/src/FPP-HomeAssistant.cpp
+++ b/src/FPP-HomeAssistant.cpp
@@ -323,7 +323,7 @@ private:
             config["command_topic"] = cmdTopic;
 
         std::string configStr = SaveJsonToString(config);
-        mqtt->PublishRaw(cfgTopic, configStr);
+        mqtt->PublishRaw(cfgTopic, configStr, true);
 
         // Store a copy of this so we can detect when we remove models
         cfgTopic = "ha/";
@@ -331,7 +331,7 @@ private:
         cfgTopic += "/";
         cfgTopic += id;
         cfgTopic += "/config";
-        mqtt->Publish(cfgTopic, configStr);
+        mqtt->Publish(cfgTopic, configStr, true);
     }
 
     void RemoveHomeAssistantDiscoveryConfig(const std::string &component, const std::string &id)


### PR DESCRIPTION
Ensures the entities in Home Assistant survive a restart of Home Assistant.