### PR TITLE
#14 Don't set device_class to None

### DIFF
--- a/src/FPP-HomeAssistant.cpp
+++ b/src/FPP-HomeAssistant.cpp
@@ -405,7 +405,9 @@ private:
             Json::Value s;
 
             if (gpio["Component"].asString() == "binary_sensor") {
-                s["device_class"] = gpio["DeviceClass"].asString();
+                if (gpio["DeviceClass"].asString() != "None") {
+                    s["device_class"] = gpio["DeviceClass"].asString();
+                }
             }
 
             AddHomeAssistantDiscoveryConfig(gpio["Component"].asString(), gpio["DeviceName"].asString(), s);


### PR DESCRIPTION
"None" is an invalid value for "device_class" on a binary_sensor. None should just leave the attribute unset